### PR TITLE
Compare checksums for file validity

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # shellcheck disable=SC1090

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -24,7 +24,7 @@ do
       tar -cf - "${path}" | gzip --no-name > "${filename}.tar.gz"
     fi
 
-    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64 |sed 's/\n//g')"
+    md5localobject="$(openssl md5 "${filename}.tar.gz" |awk '{print $2}')"
 
     # remove '/' as it breaks S3 pathing
     # remove ' ' as it breaks aws s3 cp command

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # shellcheck disable=SC1090

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,44 +10,43 @@ paths=( $(plugin_read_list CACHED_FOLDERS) )
 for path in "${paths[@]}"
 do
   # if the path is bad - skip it, don't break things
-  if [[ -d ${path} ]]; then
-    filename=`echo ${path} |sed 's/\//_/g'`
+  if [[ -d "${path}" ]]; then
+    filename=`echo "${path}" |sed 's/\//_/g'`
 
     # remove trailing '-' from filename
-    if [[ ${filename: -1} == "_" ]]; then
-      filename=${filename::${#filename}-1}
+    if [[ "${filename: -1}" == "_" ]]; then
+      filename="${filename::${#filename}-1}"
     fi
 
-    if [[ $OSTYPE != "msys" ]]; then
-      sudo tar -cf - ${path} | gzip --no-name > ${filename}.tar.gz
+    if [[ "${OSTYPE}" != "msys" ]]; then
+      sudo tar -cf - "${path}" | gzip --no-name > "${filename}.tar.gz"
     else
-      tar -cf - ${path} | gzip --no-name > ${filename}.tar.gz
+      tar -cf - "${path}" | gzip --no-name > "${filename}.tar.gz"
     fi
 
-    md5localobject=$(openssl md5 ${filename}.tar.gz |base64)
-    echo ${md5localobject}
+    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64)"
 
     # remove '/' as it breaks S3 pathing
     # remove ' ' as it breaks aws s3 cp command
-    label=${BUILDKITE_LABEL//\//}
-    label=${label// /_}
+    label="${BUILDKITE_LABEL//\//}"
+    label="${label// /_}"
 
     s3_bucket="s3://${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}/${BUILDKITE_PIPELINE_SLUG}/${label}"
 
     # check if the tar file exists
-    if aws s3 ls ${s3_bucket}/${filename}.tar.gz; then
+    if aws s3 ls "${s3_bucket}/${filename}.tar.gz"; then
       echo "comparing checksums..."
-      md5s3object=$(aws s3api head-object --bucket ${BUILDKITE_PLUGIN_CACHE_S3_BUCKET} --key ${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz | jq -r '.Metadata.md5checksum')
+      md5s3object="$(aws s3api head-object --bucket "${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}" --key "${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz" | jq -r '.Metadata.md5checksum')"
 
-      if [[ ${md5s3object} != "null" ]] && [[ ${md5s3object} == ${md5localobject} ]]; then
+      if [[ "${md5s3object}" != "null" ]] && [[ "${md5s3object}" == "${md5localobject}" ]]; then
         echo "skipping upload, checksums are identical"
       else
         echo "copying cache into s3"
-        aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
+        aws s3 cp "${filename}.tar.gz" "${s3_bucket}/${filename}.tar.gz" --metadata md5checksum="${md5localobject}"
       fi
     else
       echo "copying cache into s3"
-      aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
+      aws s3 cp "${filename}.tar.gz" "${s3_bucket}/${filename}.tar.gz" --metadata md5checksum="${md5localobject}"
     fi
   else
     echo "skipping, ${path} is not a directory"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -24,7 +24,7 @@ do
       tar -cf - "${path}" | gzip --no-name > "${filename}.tar.gz"
     fi
 
-    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64)"
+    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64 |sed 's/\n//g')"
 
     # remove '/' as it breaks S3 pathing
     # remove ' ' as it breaks aws s3 cp command

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -25,6 +25,7 @@ do
     fi
 
     md5localobject=$(openssl md5 ${filename}.tar.gz |base64)
+    echo ${md5localobject}
 
     # remove '/' as it breaks S3 pathing
     # remove ' ' as it breaks aws s3 cp command
@@ -38,13 +39,8 @@ do
       echo "comparing checksums..."
       md5s3object=$(aws s3api head-object --bucket ${BUILDKITE_PLUGIN_CACHE_S3_BUCKET} --key ${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz | jq -r '.Metadata.md5checksum')
 
-      if [[ ${md5s3object} != "null" ]]; then
-        if [[ ${md5s3object} == ${md5localobject} ]]; then
-          echo "skipping upload, checksums are identical"
-        else
-          echo "copying cache into s3"
-          aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
-        fi
+      if [[ ${md5s3object} != "null" ]] && [[ ${md5s3object} == ${md5localobject} ]]; then
+        echo "skipping upload, checksums are identical"
       else
         echo "copying cache into s3"
         aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ue
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
@@ -19,12 +18,13 @@ do
       filename=${filename::${#filename}-1}
     fi
 
-    echo "--- compressing ${path}"
-    if [[ $OSTYPE != "msys" ]] ; then
-      sudo tar -czf ${filename}.tar.gz ${path}	
-    else	
-      tar -czf ${filename}.tar.gz ${path}	
+    if [[ $OSTYPE != "msys" ]]; then
+      sudo tar -cf - ${path} | gzip --no-name > ${filename}.tar.gz
+    else
+      tar -cf - ${path} | gzip --no-name > ${filename}.tar.gz
     fi
+
+    md5localobject=$(openssl md5 ${filename}.tar.gz |base64)
 
     # remove '/' as it breaks S3 pathing
     # remove ' ' as it breaks aws s3 cp command
@@ -33,9 +33,27 @@ do
 
     s3_bucket="s3://${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}/${BUILDKITE_PIPELINE_SLUG}/${label}"
 
-    echo "--- cp ${filename}.tar.gz into :aws: :amazon-s3:"
-    aws s3 cp "${filename}.tar.gz" "${s3_bucket}/${filename}.tar.gz"
+    # check if the tar file exists
+    if aws s3 ls ${s3_bucket}/${filename}.tar.gz; then
+      echo "comparing checksums..."
+      md5s3object=$(aws s3api head-object --bucket ${BUILDKITE_PLUGIN_CACHE_S3_BUCKET} --key ${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz | jq -r '.Metadata.md5checksum')
+
+      if [[ ${md5s3object} != "null" ]]; then
+        if [[ ${md5s3object} == ${md5localobject} ]]; then
+          echo "skipping upload, checksums are identical"
+        else
+          echo "copying cache into s3"
+          aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
+        fi
+      else
+        echo "copying cache into s3"
+        aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
+      fi
+    else
+      echo "copying cache into s3"
+      aws s3 cp ${filename}.tar.gz ${s3_bucket}/${filename}.tar.gz --metadata md5checksum=${md5localobject}
+    fi
   else
-    echo "--- skipping, ${path} is not a directory"
+    echo "skipping, ${path} is not a directory"
   fi
 done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -30,7 +30,7 @@ do
 
     echo "comparing checksums..."
     md5s3object="$(aws s3api head-object --bucket "${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}" --key "${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz" | jq -r '.Metadata.md5checksum')"
-    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64)"
+    md5localobject="$(openssl md5 "${filename}.tar.gz" |awk '{print $2}')"
 
     if [[ "${md5s3object}" != "null" ]]; then
       if [[ "${md5s3object}" == "${md5localobject}" ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -23,19 +23,39 @@ do
 
   s3_bucket="s3://${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}/${BUILDKITE_PIPELINE_SLUG}/${label}"
 
-  aws s3 ls ${s3_bucket}/${filename}.tar.gz
-  rc=$?
-  if [[ ${rc} -eq 0 ]]; then
-    echo "--- :aws: :amazon-s3: cp ${filename}"
-    aws s3 cp "${s3_bucket}/${filename}.tar.gz" "."
-    
-    echo "--- untar into ${path}"
-    if [[ $OSTYPE != "msys" ]] ; then
-      sudo tar -xzf ${filename}.tar.gz	
-    else	
-      tar -xzf ${filename}.tar.gz	
+  # check if the tar file exists
+  if aws s3 ls ${s3_bucket}/${filename}.tar.gz; then
+    echo "aws s3 cp ${filename}"
+    aws s3 cp ${s3_bucket}/${filename}.tar.gz .
+
+    echo "comparing checksums..."
+    md5s3object=$(aws s3api head-object --bucket ${BUILDKITE_PLUGIN_CACHE_S3_BUCKET} --key ${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz | jq -r '.Metadata.md5checksum')
+    md5localobject=$(openssl md5 ${filename}.tar.gz |base64)
+
+    if [[ ${md5s3object} != "null" ]]; then
+      if [[ ${md5s3object} == ${md5localobject} ]]; then
+        echo "untar into ${path}"
+        if [[ $OSTYPE != "msys" ]]; then
+          sudo tar -xzf ${filename}.tar.gz
+        else
+          tar -xzf ${filename}.tar.gz
+        fi
+      else
+        echo "checksums differ, skipping extraction"
+      fi
+    else
+      if ! tar -tf ${filename}.tar.gz > /dev/null; then
+        echo "tarball cannot be opened, may be corrupted, skipping extraction"
+      else
+        echo "untar into ${path}"
+        if [[ $OSTYPE != "msys" ]]; then
+          sudo tar -xzf ${filename}.tar.gz
+        else
+          tar -xzf ${filename}.tar.gz
+        fi
+      fi
     fi
-  else 
-    echo "-- skipping :aws: :amazon-s3: cp as ${filename}.tar.gz does not exist in ${s3_bucket}"
+  else
+    echo "skipping aws s3 cp as ${filename}.tar.gz does not exist in ${s3_bucket}"
   fi
 done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,49 +9,49 @@ paths=( $(plugin_read_list CACHED_FOLDERS) )
 
 for path in "${paths[@]}"
 do
-  filename=`echo ${path} |sed 's/\//_/g'`
+  filename=`echo "${path}" |sed 's/\//_/g'`
 
   # remove trailing '-' from filename
-  if [[ ${filename: -1} == "_" ]]; then
-    filename=${filename::${#filename}-1}
+  if [[ "${filename: -1}" == "_" ]]; then
+    filename="${filename::${#filename}-1}"
   fi
 
   # remove '/' as it breaks S3 pathing
   # remove ' ' as it breaks aws s3 cp command
-  label=${BUILDKITE_LABEL//\//}
-  label=${label// /_}
+  label="${BUILDKITE_LABEL//\//}"
+  label="${label// /_}"
 
   s3_bucket="s3://${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}/${BUILDKITE_PIPELINE_SLUG}/${label}"
 
   # check if the tar file exists
-  if aws s3 ls ${s3_bucket}/${filename}.tar.gz; then
+  if aws s3 ls "${s3_bucket}/${filename}.tar.gz"; then
     echo "aws s3 cp ${filename}"
-    aws s3 cp ${s3_bucket}/${filename}.tar.gz .
+    aws s3 cp "${s3_bucket}/${filename}.tar.gz" .
 
     echo "comparing checksums..."
-    md5s3object=$(aws s3api head-object --bucket ${BUILDKITE_PLUGIN_CACHE_S3_BUCKET} --key ${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz | jq -r '.Metadata.md5checksum')
-    md5localobject=$(openssl md5 ${filename}.tar.gz |base64)
+    md5s3object="$(aws s3api head-object --bucket "${BUILDKITE_PLUGIN_CACHE_S3_BUCKET}" --key "${BUILDKITE_PIPELINE_SLUG}/${label}/${filename}.tar.gz" | jq -r '.Metadata.md5checksum')"
+    md5localobject="$(openssl md5 "${filename}.tar.gz" |base64)"
 
-    if [[ ${md5s3object} != "null" ]]; then
-      if [[ ${md5s3object} == ${md5localobject} ]]; then
+    if [[ "${md5s3object}" != "null" ]]; then
+      if [[ "${md5s3object}" == "${md5localobject}" ]]; then
         echo "untar into ${path}"
-        if [[ $OSTYPE != "msys" ]]; then
-          sudo tar -xzf ${filename}.tar.gz
+        if [[ "${OSTYPE}" != "msys" ]]; then
+          sudo tar -xzf "${filename}.tar.gz"
         else
-          tar -xzf ${filename}.tar.gz
+          tar -xzf "${filename}.tar.gz"
         fi
       else
         echo "checksums differ, skipping extraction"
       fi
     else
-      if ! tar -tf ${filename}.tar.gz > /dev/null; then
+      if ! tar -tf "${filename}.tar.gz" > /dev/null; then
         echo "tarball cannot be opened, may be corrupted, skipping extraction"
       else
         echo "untar into ${path}"
         if [[ $OSTYPE != "msys" ]]; then
-          sudo tar -xzf ${filename}.tar.gz
+          sudo tar -xzf "${filename}.tar.gz"
         else
-          tar -xzf ${filename}.tar.gz
+          tar -xzf "${filename}.tar.gz"
         fi
       fi
     fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,24 +1,22 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
-
-# Uncomment to enable stub debugging
-# export GIT_STUB_DEBUG=/dev/tty
+#load '/usr/local/lib/bats/load.bash'
 
 @test "Pre-command copies down cache if it exists" {
-  
-  stub aws \
-   "aws s3 cp s3://my-bucket/my-pipeline/my-label/my-directory.tar.gz . : echo cp s3"
-  
-  
   export BUILDKITE_ORGANIZATION_SLUG="my-org"
   export BUILDKITE_PIPELINE_SLUG="my-pipeline"
   export BUILDKITE_PLUGIN_CACHE_CACHED_FOLDERS_0="my_directory/"
   export BUILDKITE_PLUGIN_CACHE_S3_BUCKET="my-bucket"
-  run "$PWD/hooks/pre-command"
+
+  stub aws \
+    "aws s3 cp s3://my-bucket/my-pipeline/my-label/my-directory.tar.gz . : echo s3 cp"
+
+  run $PWD/hooks/pre-command
   
   assert_success
-  assert_output --partial "cp s3 "
+  assert_output --partial "s3 cp"
+
+  unstub aws
   
   unset BUILDKITE_PLUGIN_CACHE_CACHED_FOLDERS_0
   unset BUILDKITE_PIPELINE_SLUG
@@ -26,19 +24,21 @@ load "$BATS_PATH/load.bash"
   unset BUILDKITE_PLUGIN_CACHE_S3_BUCKET
 }
 
-@test "Post-command copies cach to S3" {
-
-  stub aws \
-   "aws s3 cp my-directory.tar.gz s3://my-bucket/my-pipeline/my-label/my-directory.tar.gz : echo cp cache"
-
+@test "Post-command copies cache to S3" {
   export BUILDKITE_ORGANIZATION_SLUG="my-org"
   export BUILDKITE_PIPELINE_SLUG="my-pipeline"
   export BUILDKITE_PLUGIN_CACHE_CACHED_FOLDERS_0="my_directory/"
   export BUILDKITE_PLUGIN_CACHE_S3_BUCKET="my-bucket"
-  run "$PWD/hooks/post-command"
+
+  stub aws \
+   "aws s3 cp my-directory.tar.gz s3://my-bucket/my-pipeline/my-label/my-directory.tar.gz : echo s3 cp"
+
+  run $PWD/hooks/post-command
 
   assert_success
-  assert_output --partial "cp cache"
+  assert_output --partial "s3 cp"
+
+  unstub aws
 
   unset BUILDKITE_PLUGIN_CACHE_CACHED_FOLDERS_0
   unset BUILDKITE_PIPELINE_SLUG


### PR DESCRIPTION
This will allow us to run comparison checks against tarballs via
checksums by comparing S3Object metadata against the local dir
needed to be cached.
Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>